### PR TITLE
🏷️ 修复类型注解

### DIFF
--- a/hibiapi/utils/log.py
+++ b/hibiapi/utils/log.py
@@ -52,7 +52,7 @@ class LoguruHandler(logging.Handler):
             level = record.levelno  # type:ignore
 
         frame, depth, message = logging.currentframe(), 2, record.getMessage()
-        while frame.f_code.co_filename == logging.__file__:
+        while frame.f_code.co_filename == logging.__file__:  # type:ignore
             frame = frame.f_back  # type:ignore
             depth += 1
 

--- a/hibiapi/utils/net.py
+++ b/hibiapi/utils/net.py
@@ -105,16 +105,16 @@ class BaseNetClient:
         )
 
 
-def catch_network_error(function: _AsyncCallable) -> _AsyncCallable:
-    function = TimeIt(function)
+def catch_network_error(function: Callable) -> Callable:
+    timed_func = TimeIt(function)
 
-    @wraps(function)
+    @wraps(timed_func)
     async def wrapper(*args, **kwargs):
         try:
-            return await function(*args, **kwargs)
+            return await timed_func(*args, **kwargs)
         except HTTPStatusError as e:
             raise UpstreamAPIException(detail=e.response.text) from e
         except HTTPError as e:
             raise UpstreamAPIException from e
 
-    return wrapper  # type:ignore
+    return wrapper

--- a/poetry.lock
+++ b/poetry.lock
@@ -86,7 +86,7 @@ tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>
 
 [[package]]
 name = "black"
-version = "21.6b0"
+version = "21.7b0"
 description = "The uncompromising code formatter."
 category = "dev"
 optional = false
@@ -98,7 +98,7 @@ click = ">=7.1.2"
 mypy-extensions = ">=0.4.3"
 pathspec = ">=0.8.1,<1"
 regex = ">=2020.1.8"
-toml = ">=0.10.1"
+tomli = ">=0.2.6,<2.0.0"
 
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
@@ -624,6 +624,14 @@ optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "tomli"
+version = "1.0.4"
+description = "A lil' TOML parser"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "types-click"
 version = "7.1.2"
 description = "Typing stubs for click"
@@ -726,8 +734,8 @@ attrs = [
     {file = "attrs-21.2.0.tar.gz", hash = "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"},
 ]
 black = [
-    {file = "black-21.6b0-py3-none-any.whl", hash = "sha256:dfb8c5a069012b2ab1e972e7b908f5fb42b6bbabcba0a788b86dc05067c7d9c7"},
-    {file = "black-21.6b0.tar.gz", hash = "sha256:dc132348a88d103016726fe360cb9ede02cecf99b76e3660ce6c596be132ce04"},
+    {file = "black-21.7b0-py3-none-any.whl", hash = "sha256:1c7aa6ada8ee864db745b22790a32f94b2795c253a75d6d9b5e439ff10d23116"},
+    {file = "black-21.7b0.tar.gz", hash = "sha256:c8373c6491de9362e39271630b65b964607bc5c79c83783547d76c839b3aa219"},
 ]
 certifi = [
     {file = "certifi-2021.5.30-py2.py3-none-any.whl", hash = "sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"},
@@ -1163,6 +1171,10 @@ starlette = [
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+tomli = [
+    {file = "tomli-1.0.4-py3-none-any.whl", hash = "sha256:0713b16ff91df8638a6a694e295c8159ab35ba93e3424a626dd5226d386057be"},
+    {file = "tomli-1.0.4.tar.gz", hash = "sha256:be670d0d8d7570fd0ea0113bd7bb1ba3ac6706b4de062cc4c952769355c9c268"},
 ]
 types-click = [
     {file = "types-click-7.1.2.tar.gz", hash = "sha256:040897284e4f9466825c3865f708a985a8e7ba4d8e22cb9198ffb7b522160850"},


### PR DESCRIPTION
`Retry` 是一个装饰器，如果它（`Retry`）接受位置参数（`Callable`），则返回被包装的函数（`Callable`）；如果它接受关键字参数，则返回 `RetryT` 协议类型，它实现了 Callback 协议。`RetryT` 的签名大致理解为和 `Retry` 一样。如果它（`RetryT`）接受位置参数，则返回被包装的函数，如果接受关键字参数，则返回 `RetryT` 。也就是说，和 `partial` 对应，如果只调用关键字参数，则在类型上是幂等的。

带 bound 的泛型标红了，奇怪，最简单的话还是直接用 `Callable`，如下：

```python
def Retry(
    function: Optional[Callable] = None,
    *,
    retries: int = 3,
    delay: float = 0.1,
    exceptions: Optional[Tuple[Type[Exception], ...]] = None,
) -> Union[Callable, Callable[[Callable], Callable]]:
```

甚至

```python
) -> Callable:
```

参考：
https://stackoverflow.com/questions/66663571/proper-type-hint-for-functools-partial
https://www.python.org/dev/peps/pep-0484/#function-method-overloading
https://www.python.org/dev/peps/pep-0544/#callback-protocols

另一个点就是函数形参变量重新赋值的话类型也需要和签名匹配，
`function = TimeIt(function)` 标红了。