### PR TITLE
feat: 添加几条 Pixiv API

### DIFF
--- a/hibiapi/api/pixiv/api.py
+++ b/hibiapi/api/pixiv/api.py
@@ -279,15 +279,19 @@ class PixivEndpoints(BaseEndpoint):
         self,
         *,
         word: str,
+        mode: SearchModeType = SearchModeType.partial_match_for_tags,
+        merge_plain_keyword_results: bool = True,
+        include_translated_tag_results: bool = True,
+        filter: str = "for_ios",
     ):
         return await self.request(
             "v1/search/popular-preview/illust",
             params={
                 "word": word,
-                "filter": "for_ios",
-                "include_translated_tag_results": "true",
-                "merge_plain_keyword_results": "true",
-                "search_target": "partial_match_for_tags",
+                "search_target": mode,
+                "merge_plain_keyword_results": merge_plain_keyword_results,
+                "include_translated_tag_results": include_translated_tag_results,
+                "filter": filter,
             },
         )
 
@@ -376,15 +380,14 @@ class PixivEndpoints(BaseEndpoint):
         self,
         *,
         id: int,
-        offset: Optional[int] = None,
-        include_total_comments: Optional[bool] = None,
+        page: int = 1,
+        size: int = 30,
     ):
         return await self.request(
             "v3/illust/comments",
             params={
                 "illust_id": id,
-                "offset": offset,
-                "include_total_comments": include_total_comments,
+                "offset": (page - 1) * size,
             },
         )
 
@@ -406,15 +409,14 @@ class PixivEndpoints(BaseEndpoint):
         self,
         *,
         id: int,
-        offset: Optional[int] = None,
-        include_total_comments: Optional[bool] = None,
+        page: int = 1,
+        size: int = 30,
     ):
         return await self.request(
             "v3/novel/comments",
             params={
                 "novel_id": id,
-                "offset": offset,
-                "include_total_comments": include_total_comments,
+                "offset": (page - 1) * size,
             },
         )
 
@@ -467,6 +469,7 @@ class PixivEndpoints(BaseEndpoint):
     async def novel_text(self, *, id: int):
         return await self.request("/v1/novel/text", params={"novel_id": id})
 
+    @cache_config(ttl=timedelta(hours=12)) 
     async def tags_novel(self):
         return await self.request("v1/trending-tags/novel")
 
@@ -500,15 +503,19 @@ class PixivEndpoints(BaseEndpoint):
         self,
         *,
         word: str,
+        mode: SearchNovelModeType = SearchNovelModeType.partial_match_for_tags,
+        merge_plain_keyword_results: bool = True,
+        include_translated_tag_results: bool = True,
+        filter: str = "for_ios",
     ):
         return await self.request(
             "v1/search/popular-preview/novel",
             params={
                 "word": word,
-                "filter": "for_ios",
-                "include_translated_tag_results": "true",
-                "merge_plain_keyword_results": "true",
-                "search_target": "partial_match_for_tags",
+                "search_target": mode,
+                "merge_plain_keyword_results": merge_plain_keyword_results,
+                "include_translated_tag_results": include_translated_tag_results,
+                "filter": filter,
             },
         )
 

--- a/hibiapi/api/pixiv/api.py
+++ b/hibiapi/api/pixiv/api.py
@@ -198,7 +198,7 @@ class PixivEndpoints(BaseEndpoint):
                 "max_bookmark_id": max_bookmark_id or None,
             },
         )
-    
+
     # 用户收藏的小说
     async def favorite_novel(
         self,
@@ -209,9 +209,9 @@ class PixivEndpoints(BaseEndpoint):
         return await self.request(
             "v1/user/bookmarks/novel",
             params={
-               "user_id": id,
-               "tag": tag,
-               "restrict": "public",
+                "user_id": id,
+                "tag": tag,
+                "restrict": "public",
             },
         )
 
@@ -353,7 +353,7 @@ class PixivEndpoints(BaseEndpoint):
                 "filter": "for_ios",
             },
         )
-    
+
     # pixivision(亮点/特辑) 列表
     async def spotlights(
         self,
@@ -430,7 +430,7 @@ class PixivEndpoints(BaseEndpoint):
                 "comment_id": id,
             },
         )
-    
+
     # 小说排行榜
     async def rank_novel(
         self,

--- a/hibiapi/api/pixiv/api.py
+++ b/hibiapi/api/pixiv/api.py
@@ -469,7 +469,7 @@ class PixivEndpoints(BaseEndpoint):
     async def novel_text(self, *, id: int):
         return await self.request("/v1/novel/text", params={"novel_id": id})
 
-    @cache_config(ttl=timedelta(hours=12)) 
+    @cache_config(ttl=timedelta(hours=12))
     async def tags_novel(self):
         return await self.request("v1/trending-tags/novel")
 

--- a/hibiapi/api/pixiv/api.py
+++ b/hibiapi/api/pixiv/api.py
@@ -198,6 +198,22 @@ class PixivEndpoints(BaseEndpoint):
                 "max_bookmark_id": max_bookmark_id or None,
             },
         )
+    
+    # 用户收藏的小说
+    async def favorite_novel(
+        self,
+        *,
+        id: int,
+        tag: Optional[str] = None,
+    ):
+        return await self.request(
+            "v1/user/bookmarks/novel",
+            params={
+               "user_id": id,
+               "tag": tag,
+               "restrict": "public",
+            },
+        )
 
     async def following(self, *, id: int, page: int = 1, size: int = 30):
         return await self.request(
@@ -258,6 +274,23 @@ class PixivEndpoints(BaseEndpoint):
             },
         )
 
+    # 热门插画作品预览
+    async def popular_preview(
+        self,
+        *,
+        word: str,
+    ):
+        return await self.request(
+            "v1/search/popular-preview/illust",
+            params={
+                "word": word,
+                "filter": "for_ios",
+                "include_translated_tag_results": "true",
+                "merge_plain_keyword_results": "true",
+                "search_target": "partial_match_for_tags",
+            },
+        )
+
     async def search_user(
         self,
         *,
@@ -307,6 +340,115 @@ class PixivEndpoints(BaseEndpoint):
             },
         )
 
+    # 大家的新作品（插画）
+    async def illust_new(
+        self,
+        *,
+        content_type: str = "illust",
+    ):
+        return await self.request(
+            "v1/illust/new",
+            params={
+                "content_type": content_type,
+                "filter": "for_ios",
+            },
+        )
+    
+    # pixivision(亮点/特辑) 列表
+    async def spotlights(
+        self,
+        *,
+        category: str = "all",
+        page: int = 1,
+        size: int = 10,
+    ):
+        return await self.request(
+            "v1/spotlight/articles",
+            params={
+                "filter": "for_ios",
+                "category": category,
+                "offset": (page - 1) * size,
+            },
+        )
+
+    # 插画评论
+    async def illust_comments(
+        self,
+        *,
+        id: int,
+        offset: Optional[int] = None,
+        include_total_comments: Optional[bool] = None,
+    ):
+        return await self.request(
+            "v3/illust/comments",
+            params={
+                "illust_id": id,
+                "offset": offset,
+                "include_total_comments": include_total_comments,
+            },
+        )
+
+    # 插画评论回复
+    async def illust_comment_replies(
+        self,
+        *,
+        id: int,
+    ):
+        return await self.request(
+            "v2/illust/comment/replies",
+            params={
+                "comment_id": id,
+            },
+        )
+
+    # 小说评论
+    async def novel_comments(
+        self,
+        *,
+        id: int,
+        offset: Optional[int] = None,
+        include_total_comments: Optional[bool] = None,
+    ):
+        return await self.request(
+            "v3/novel/comments",
+            params={
+                "novel_id": id,
+                "offset": offset,
+                "include_total_comments": include_total_comments,
+            },
+        )
+
+    # 小说评论回复
+    async def novel_comment_replies(
+        self,
+        *,
+        id: int,
+    ):
+        return await self.request(
+            "v2/novel/comment/replies",
+            params={
+                "comment_id": id,
+            },
+        )
+    
+    # 小说排行榜
+    async def rank_novel(
+        self,
+        *,
+        mode: str = "day",
+        date: Optional[RankingDate] = None,
+        page: int = 1,
+        size: int = 30,
+    ):
+        return await self.request(
+            "v1/novel/ranking",
+            params={
+                "mode": mode,
+                "date": RankingDate.new(date or RankingDate.yesterday()).toString(),
+                "offset": (page - 1) * size,
+            },
+        )
+
     async def member_novel(self, *, id: int, page: int = 1, size: int = 30):
         return await self.request(
             "/v1/user/novels",
@@ -324,6 +466,9 @@ class PixivEndpoints(BaseEndpoint):
 
     async def novel_text(self, *, id: int):
         return await self.request("/v1/novel/text", params={"novel_id": id})
+
+    async def tags_novel(self):
+        return await self.request("v1/trending-tags/novel")
 
     async def search_novel(
         self,
@@ -347,6 +492,23 @@ class PixivEndpoints(BaseEndpoint):
                 "include_translated_tag_results": include_translated_tag_results,
                 "duration": duration,
                 "offset": (page - 1) * size,
+            },
+        )
+
+    # 热门小说作品预览
+    async def popular_preview_novel(
+        self,
+        *,
+        word: str,
+    ):
+        return await self.request(
+            "v1/search/popular-preview/novel",
+            params={
+                "word": word,
+                "filter": "for_ios",
+                "include_translated_tag_results": "true",
+                "merge_plain_keyword_results": "true",
+                "search_target": "partial_match_for_tags",
             },
         )
 

--- a/test/test_pixiv.py
+++ b/test/test_pixiv.py
@@ -41,6 +41,9 @@ def test_favorite(client: TestClient):
     response = client.get("favorite", params={"id": 3036679})
     assert response.status_code == 200
 
+def test_favorite_novel(client: TestClient):
+    response = client.get("favorite_novel", params={"id": 55170615})
+    assert response.status_code == 200
 
 def test_following(client: TestClient):
     response = client.get("following", params={"id": 3036679})
@@ -68,6 +71,10 @@ def test_search(client: TestClient):
     assert response.status_code == 200
     assert response.json().get("illusts")
 
+def test_popular_preview(client: TestClient):
+    response = client.get("popular_preview", params={"word": "東方Project"})
+    assert response.status_code == 200
+    assert response.json().get("illusts")
 
 def test_search_user(client: TestClient):
     response = client.get("search_user", params={"word": "鬼针草"})
@@ -98,6 +105,43 @@ def test_ugoira_metadata(client: TestClient):
     assert response.status_code == 200
     assert response.json().get("ugoira_metadata")
 
+def test_spotlights(client: TestClient):
+    response = client.get("spotlights")
+    assert response.status_code == 200
+    assert response.json().get("spotlight_articles")
+
+def test_illust_new(client: TestClient):
+    response = client.get("illust_new")
+    assert response.status_code == 200
+    assert response.json().get("illusts")
+
+def test_illust_comments(client: TestClient):
+    response = client.get("illust_comments", params={"id": 99973718})
+    assert response.status_code == 200
+    assert response.json().get("comments")
+
+def test_illust_comment_replies(client: TestClient):
+    response = client.get("illust_comment_replies", params={"id": 151400579})
+    assert response.status_code == 200
+    assert response.json().get("comments")
+
+def test_novel_comments(client: TestClient):
+    response = client.get("novel_comments", params={"id": 19205075})
+    assert response.status_code == 200
+    assert response.json().get("comments")
+
+def test_novel_comment_replies(client: TestClient):
+    response = client.get("novel_comment_replies", params={"id": 41470327})
+    assert response.status_code == 200
+    assert response.json().get("comments")
+
+def test_rank_novel(client: TestClient):
+    for i in range(2, 5):
+        response = client.get(
+            "rank_novel", params={"date": str(date.today() - timedelta(days=i))}
+        )
+        assert response.status_code == 200
+        assert response.json().get("novels")
 
 def test_member_novel(client: TestClient):
     response = client.get("member_novel", params={"id": 14883165})
@@ -122,12 +166,20 @@ def test_novel_text(client: TestClient):
     assert response.status_code == 200
     assert response.json().get("novel_text")
 
+def test_tags_novel(client: TestClient):
+    response = client.get("tags_novel")
+    assert response.status_code == 200
+    assert response.json().get("trend_tags")
 
 def test_search_novel(client: TestClient):
     response = client.get("search_novel", params={"word": "碧蓝航线"})
     assert response.status_code == 200
     assert response.json().get("novels")
 
+def test_popular_preview_novel(client: TestClient):
+    response = client.get("popular_preview_novel", params={"word": "東方Project"})
+    assert response.status_code == 200
+    assert response.json().get("novels")
 
 def test_novel_new(client: TestClient):
     response = client.get("novel_new", params={"max_novel_id": 16002726})

--- a/test/test_pixiv.py
+++ b/test/test_pixiv.py
@@ -41,9 +41,11 @@ def test_favorite(client: TestClient):
     response = client.get("favorite", params={"id": 3036679})
     assert response.status_code == 200
 
+
 def test_favorite_novel(client: TestClient):
     response = client.get("favorite_novel", params={"id": 55170615})
     assert response.status_code == 200
+
 
 def test_following(client: TestClient):
     response = client.get("following", params={"id": 3036679})
@@ -71,10 +73,12 @@ def test_search(client: TestClient):
     assert response.status_code == 200
     assert response.json().get("illusts")
 
+
 def test_popular_preview(client: TestClient):
     response = client.get("popular_preview", params={"word": "東方Project"})
     assert response.status_code == 200
     assert response.json().get("illusts")
+
 
 def test_search_user(client: TestClient):
     response = client.get("search_user", params={"word": "鬼针草"})
@@ -105,35 +109,42 @@ def test_ugoira_metadata(client: TestClient):
     assert response.status_code == 200
     assert response.json().get("ugoira_metadata")
 
+
 def test_spotlights(client: TestClient):
     response = client.get("spotlights")
     assert response.status_code == 200
     assert response.json().get("spotlight_articles")
+
 
 def test_illust_new(client: TestClient):
     response = client.get("illust_new")
     assert response.status_code == 200
     assert response.json().get("illusts")
 
+
 def test_illust_comments(client: TestClient):
     response = client.get("illust_comments", params={"id": 99973718})
     assert response.status_code == 200
     assert response.json().get("comments")
+
 
 def test_illust_comment_replies(client: TestClient):
     response = client.get("illust_comment_replies", params={"id": 151400579})
     assert response.status_code == 200
     assert response.json().get("comments")
 
+
 def test_novel_comments(client: TestClient):
     response = client.get("novel_comments", params={"id": 19205075})
     assert response.status_code == 200
     assert response.json().get("comments")
 
+
 def test_novel_comment_replies(client: TestClient):
     response = client.get("novel_comment_replies", params={"id": 41470327})
     assert response.status_code == 200
     assert response.json().get("comments")
+
 
 def test_rank_novel(client: TestClient):
     for i in range(2, 5):
@@ -142,6 +153,7 @@ def test_rank_novel(client: TestClient):
         )
         assert response.status_code == 200
         assert response.json().get("novels")
+
 
 def test_member_novel(client: TestClient):
     response = client.get("member_novel", params={"id": 14883165})
@@ -166,20 +178,24 @@ def test_novel_text(client: TestClient):
     assert response.status_code == 200
     assert response.json().get("novel_text")
 
+
 def test_tags_novel(client: TestClient):
     response = client.get("tags_novel")
     assert response.status_code == 200
     assert response.json().get("trend_tags")
+
 
 def test_search_novel(client: TestClient):
     response = client.get("search_novel", params={"word": "碧蓝航线"})
     assert response.status_code == 200
     assert response.json().get("novels")
 
+
 def test_popular_preview_novel(client: TestClient):
     response = client.get("popular_preview_novel", params={"word": "東方Project"})
     assert response.status_code == 200
     assert response.json().get("novels")
+
 
 def test_novel_new(client: TestClient):
     response = client.get("novel_new", params={"max_novel_id": 16002726})


### PR DESCRIPTION
新增了如下几条 API


- 热门插画作品预览
- 大家的新作品（插画）
- pixivision(亮点/特辑) 列表
- 插画评论列表
- 插画评论回复
- 小说排行榜
- 热门小说标签
- 热门小说作品预览
- 用户收藏的小说
- 小说评论列表
- 小说评论回复

都没有设置 `@cache_config`
